### PR TITLE
Invalid site_preference parameter value results in IllegalArgumentException

### DIFF
--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/StandardSitePreferenceHandler.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/StandardSitePreferenceHandler.java
@@ -63,7 +63,11 @@ public class StandardSitePreferenceHandler implements SitePreferenceHandler {
 	
 	private SitePreference getSitePreferenceQueryParameter(HttpServletRequest request) {
 		String string = request.getParameter(SITE_PREFERENCE_PARAMETER);
-		return string != null && string.length() > 0 ? SitePreference.valueOf(string.toUpperCase()) : null;
+		try {
+			return string != null && string.length() > 0 ? SitePreference.valueOf(string.toUpperCase()) : null;
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 	}
 
 	private SitePreference getDefaultSitePreferenceForDevice(Device device) {

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/StandardSitePreferenceHandlerTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/StandardSitePreferenceHandlerTest.java
@@ -26,6 +26,14 @@ public class StandardSitePreferenceHandlerTest {
 	}
 	
 	@Test
+	public void saveInvalidSitePreference() throws Exception {
+		request.addParameter("site_preference", "invalid");
+		assertEquals(null, sitePreferenceHandler.handleSitePreference(request, response));
+		assertEquals(null, sitePreferenceRepository.getSitePreference());
+		assertEquals(null, SitePreferenceUtils.getCurrentSitePreference(request));
+	}
+	
+	@Test
 	public void saveSitePreference() throws Exception {
 		request.addParameter("site_preference", "normal");
 		assertEquals(SitePreference.NORMAL, sitePreferenceHandler.handleSitePreference(request, response));


### PR DESCRIPTION
Using anything other than "normal" or "mobile" for the site_preference parameter value results in an IllegalArgumentException being thrown from the StandardSitePreferenceHandler. 
