### PR TITLE
Resolves MOBILE-30.

### DIFF
--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactory.java
@@ -1,0 +1,35 @@
+package org.springframework.mobile.device.switcher;
+
+
+/**
+ * Abstract {@link SiteUrlFactory} implementation that differentiates each site by the 
+ * HTTP request path.  Provides functionality common to all path based site URL factories. 
+ * 
+ * @author Scott Rossillo
+ *
+ */
+public abstract class AbstractSitePathUrlFactory extends AbstractSiteUrlFactory implements SiteUrlFactory {
+	
+	private final String mobilePath;
+	
+	/**
+	 * Creates a new abstract site path URL factory for the given mobile path.
+	 */
+	public AbstractSitePathUrlFactory(final String mobilePath) {
+		this.mobilePath = (mobilePath.endsWith("/") ? mobilePath : mobilePath + "/");
+	}
+	
+	/**
+	 * Returns the mobile path with a trailing slash character.
+	 */
+	public String getMobilePath() {
+		return mobilePath;
+	}
+	
+	/**
+	 * Returns the mobile path without a trailing slash.
+	 */
+	protected String getCleanMobilePath() {
+		return mobilePath.substring(0, mobilePath.length() - 1);
+	}
+}

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSiteUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSiteUrlFactory.java
@@ -1,0 +1,32 @@
+package org.springframework.mobile.device.switcher;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Abstract implementation of the {@link SiteUrlFactory} interface.
+ * Doesn't mandate the strategy for constructing different site URLs; 
+ * simply implements common functionality.
+ *  
+ * @author Scott Rossillo
+ *
+ */
+public abstract class AbstractSiteUrlFactory implements SiteUrlFactory {
+
+	/**
+	 * Returns the HTTP port specified on the given request if it's a non-standard port. 
+	 * The port is considered non-standard if it's not port 80 for insecure request and not 
+	 * port 443 of secure requests.
+	 * 
+	 * @param request the <code>HttpServletRequest</code> to check for a non-standard port.
+	 *  
+	 * @return the HTTP port specified on the given request if it's a non-standard port, <code>null<code> otherwise
+	 */
+	protected String optionalPort(HttpServletRequest request) {
+        if ("http".equals(request.getScheme()) && request.getServerPort() != 80 || "https".equals(request.getScheme()) && request.getServerPort() != 443) {
+            return ":" + request.getServerPort();
+        } else {
+        	return null;
+        }
+	}
+
+}

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactory.java
@@ -1,0 +1,35 @@
+package org.springframework.mobile.device.switcher;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Path based site URL factory implementation that handles requests for the "mobile" site.
+ * 
+ * @author Scott Rossillo
+ *
+ */
+public class MobileSitePathUrlFactory extends AbstractSitePathUrlFactory implements SiteUrlFactory {
+	
+	/**
+	 * Creates a new mobile site path URL factory.
+	 */
+	public MobileSitePathUrlFactory(final String mobilePath) {
+		super(mobilePath);
+	}
+
+	public boolean isRequestForSite(HttpServletRequest request) {
+		return request.getRequestURI().startsWith(this.getMobilePath());
+	}
+
+	public String createSiteUrl(HttpServletRequest request) {
+		final StringBuilder builder = new StringBuilder();
+		builder.append(request.getScheme()).append("://").append(request.getServerName());
+		String optionalPort = optionalPort(request);
+		if (optionalPort != null) {
+			builder.append(optionalPort);
+		}
+		builder.append(this.getCleanMobilePath()).append(request.getRequestURI());
+		
+		return builder.toString();
+	}
+}

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactory.java
@@ -1,0 +1,35 @@
+package org.springframework.mobile.device.switcher;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Path based site URL factory implementation that handles requests for the "normal" site.
+ * 
+ * @author Scott Rossillo
+ *
+ */
+public class NormalSitePathUrlFactory extends AbstractSitePathUrlFactory implements SiteUrlFactory {
+	
+	/**
+	 * Creates a new normal site path URL factory.
+	 */
+	public NormalSitePathUrlFactory(final String mobilePath) {
+		super(mobilePath);
+	}
+	
+	public boolean isRequestForSite(HttpServletRequest request) {
+		return !request.getRequestURI().startsWith(this.getMobilePath());
+	}
+
+	public String createSiteUrl(HttpServletRequest request) {
+		final StringBuilder builder = new StringBuilder();
+		builder.append(request.getScheme()).append("://").append(request.getServerName());
+		String optionalPort = optionalPort(request);
+		if (optionalPort != null) {
+			builder.append(optionalPort);
+		}
+		builder.append(request.getRequestURI().substring(this.getCleanMobilePath().length()));
+		
+		return builder.toString();
+	}
+}

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptor.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptor.java
@@ -103,4 +103,13 @@ public class SiteSwitcherHandlerInterceptor extends HandlerInterceptorAdapter {
 		return new SiteSwitcherHandlerInterceptor(new StandardSiteUrlFactory(serverName), new StandardSiteUrlFactory(serverName.substring(0, lastDot) + ".mobi"), new StandardSitePreferenceHandler(new CookieSitePreferenceRepository("." + serverName)));
 	}
 	
+	/**
+	 * Creates a site switcher that redirects to a path on the current domain for normal site requests that either
+	 * originate from a mobile device or indicate a mobile site preference.
+	 * Uses a {@link CookieSitePreferenceRepository} that saves a cookie that is stored on the root path.
+	 */
+	public static SiteSwitcherHandlerInterceptor urlPath(String mobilePath) {
+		return new SiteSwitcherHandlerInterceptor(new NormalSitePathUrlFactory(mobilePath), new MobileSitePathUrlFactory(mobilePath), new StandardSitePreferenceHandler(new CookieSitePreferenceRepository()));		
+	}
+	
 }

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteUrlFactory.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
  * For example, your 'normal' site might be bound to 'myapp.com', while your mobile site might be bound to 'm.myapp.com'. 
  * @author Keith Donald
  */
-public class StandardSiteUrlFactory implements SiteUrlFactory {
+public class StandardSiteUrlFactory extends AbstractSiteUrlFactory implements SiteUrlFactory {
 	
 	private final String serverName;
 
@@ -47,16 +47,6 @@ public class StandardSiteUrlFactory implements SiteUrlFactory {
 		}
 		builder.append(request.getRequestURI());
 		return builder.toString();
-	}
-	
-	// internal helpers
-	
-	private String optionalPort(HttpServletRequest request) {
-        if ("http".equals(request.getScheme()) && request.getServerPort() != 80 || "https".equals(request.getScheme()) && request.getServerPort() != 443) {
-            return ":" + request.getServerPort();
-        } else {
-        	return null;
-        }
 	}
 	
 }

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactoryTest.java
@@ -1,0 +1,44 @@
+package org.springframework.mobile.device.switcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public final class MobileSitePathUrlFactoryTest {
+	
+	private MobileSitePathUrlFactory factory = new MobileSitePathUrlFactory("/m");
+
+	private MockHttpServletRequest request = new MockHttpServletRequest();
+	
+	@Test
+	public void isRequestForSite() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/m/");
+		assertTrue(factory.isRequestForSite(request));
+	}
+	
+	@Test
+	public void notRequestForSite() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/");
+		assertFalse(factory.isRequestForSite(request));
+	}
+	
+	@Test
+	public void notRequestForSiteWithPath() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/marvelous/");
+		assertFalse(factory.isRequestForSite(request));
+	}
+
+	@Test
+	public void createSiteUrl() {
+		request.setServerName("www.app.com");
+		request.setServerPort(80);
+		request.setRequestURI("/foo");
+		assertEquals("http://www.app.com/m/foo", factory.createSiteUrl(request));
+	}
+}

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactoryTest.java
@@ -1,0 +1,51 @@
+package org.springframework.mobile.device.switcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public final class NormalSitePathUrlFactoryTest {
+	
+	private NormalSitePathUrlFactory factory = new NormalSitePathUrlFactory("/m");
+
+	private MockHttpServletRequest request = new MockHttpServletRequest();
+	
+	@Test
+	public void isRequestForSite() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/");
+		assertTrue(factory.isRequestForSite(request));
+	}
+	
+	@Test
+	public void isRequestForSiteWithPath() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/marvelous/");
+		assertTrue(factory.isRequestForSite(request));
+	}
+	
+	@Test
+	public void notRequestForSite() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/m/");
+		assertFalse(factory.isRequestForSite(request));
+	}
+	
+	@Test
+	public void notRequestForSiteWithPath() {
+		request.setServerName("www.app.com");
+		request.setRequestURI("/m/marvelous/");
+		assertFalse(factory.isRequestForSite(request));
+	}
+
+	@Test
+	public void createSiteUrl() {
+		request.setServerName("www.app.com");
+		request.setServerPort(80);
+		request.setRequestURI("/m/foo");
+		assertEquals("http://www.app.com/foo", factory.createSiteUrl(request));
+	}
+}

--- a/src/reference/docbook/device.xml
+++ b/src/reference/docbook/device.xml
@@ -368,16 +368,32 @@ public class HomeController {
     </beans:bean>
 </mvc:interceptors>]]>
 				</programlisting>
+			</para>			
+		</section>
+		<section id="spring-mobile-site-switcher-interceptor-urlpath">
+			<title>urlPath SiteSwitcher</title>
+			<para>
+				Use the "urlPath" factory method to construct a SiteSwitcher that redirects mobile users to ${serverName}/${mobilePath}; for example, myapp.com/m/:
+				<programlisting language="xml"><![CDATA[
+<mvc:interceptors>
+    <!-- On pre-handle, resolve the device that originated the web request -->
+    <beans:bean class="org.springframework.mobile.device.DeviceResolverHandlerInterceptor" />
+    <!-- On pre-handle, redirects mobile users to "myapp.mobi" (declare after DeviceResolverHandlerInterceptor) -->
+    <beans:bean class="org.springframework.mobile.device.switcher.SiteSwitcherHandlerInterceptor" factory-method="urlPath">
+        <beans:constructor-arg value="/m" />
+    </beans:bean>
+</mvc:interceptors>]]>
+				</programlisting>
 			</para>
 			<para>
-				Both the "mDot" and "dotMobi" factory methods configure cookie-based SitePreference storage.
+				The "mDot", "dotMobi" and "urlPath" factory methods configure cookie-based SitePreference storage.
 				The cookie value will be shared across the mobile and normal site domains.
 				Internally, the interceptor delegates to a SitePreferenceHandler, so there is no need to register a SitePreferenceHandlerInterceptor when using the switcher.
 			</para>
 			<para>
 				See the JavaDoc of SiteSwitcherHandlerInterceptor for additional options when you need more control.			
 				See the spring-mobile <ulink url="https://github.com/SpringSource/spring-mobile-samples">samples</ulink> repository for runnable SiteSwitcher examples.
-			</para>				
+			</para>
 		</section>
 	</section>
 


### PR DESCRIPTION
Assumes only the mobile site has a URL path that needs to be monitored.  The normal site is considered to reside at the root (/).
