### PR TITLE
Resolves MOBILE-39: links API to J2SE, J2EE and Spring Framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,10 @@ configure(rootProject) {
         options.header = rootProject.description
         options.overview = 'src/api/overview.html'
         options.links(
-            'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
+            'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector',
+            'http://docs.oracle.com/javase/6/docs/api',
+            'http://docs.oracle.com/javaee/6/api',
+            'http://static.springsource.org/spring/docs/3.1.x/javadoc-api' 
         )
         source subprojects.collect { project ->
             project.sourceSets.main.allJava


### PR DESCRIPTION
Linked Spring Mobile APIs to J2SE 6, J2EE 6 and Spring Framework 3.1.x.
