### PR TITLE
Made redirect and forward view resolution configurable

### DIFF
--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/view/AbstractDeviceDelegatingViewResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/view/AbstractDeviceDelegatingViewResolver.java
@@ -54,7 +54,7 @@ public abstract class AbstractDeviceDelegatingViewResolver extends WebApplicatio
 
 	private boolean enableFallback = false;
 	private boolean forwardToViews = true;
-	private boolean redirectToViews = false;
+	private boolean redirectToViews = true;
 
 	/**
 	 * Creates a new AbstractDeviceDelegatingViewResolver


### PR DESCRIPTION
In some applications, redirect: and forward: prefixes are used to redirect to a controller request mapping, not a view name.  This change adds support for configuring whether redirect: and forward: prefixes adjust the view name to a device specific view name or leave it unchanged.
