### PR TITLE
Fix handling of empty paths in AbstractSitePathUrlFactory

### DIFF
--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactory.java
@@ -194,7 +194,7 @@ public abstract class AbstractSitePathUrlFactory extends AbstractSiteUrlFactory 
 		String formattedPath = null;
 		if (path != null) {
 			formattedPath = (path.startsWith("/") ? path : "/" + path);
-			formattedPath = (path.endsWith("/") ? formattedPath : formattedPath + "/");
+			formattedPath = (formattedPath.endsWith("/") ? formattedPath : formattedPath + "/");
 		}
 		return formattedPath;
 	}

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactoryTest.java
@@ -110,7 +110,15 @@ public abstract class AbstractSitePathUrlFactoryTest {
 		assertEquals("/tablet/", factory.getTabletPath());
 		assertEquals("/root/", factory.getRootPath());
 	}
-	
+
+	@Test
+	public void formatPathWithEmptyRootPath() {
+		AbstractSitePathUrlFactory factory = new MockSitePathUrlFactory("mobile", "tablet", "");
+		assertEquals("/mobile/", factory.getMobilePath());
+		assertEquals("/tablet/", factory.getTabletPath());
+		assertEquals("/", factory.getRootPath());
+	}
+
 	private class MockSitePathUrlFactory extends AbstractSitePathUrlFactory {
 
 		public MockSitePathUrlFactory(String mobilePath, String tabletPath, String rootPath) {


### PR DESCRIPTION
The `formatPath(String path)` method in the AbstractSitePathUrlFactory class didn't handle an empty path (empty String) correctly. It would return `//` (two slashes), instead of just one.

Fixes MOBILE-113 (https://jira.spring.io/browse/MOBILE-113).
