### PR TITLE
Fix exception message in DeviceUtils class

### DIFF
--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceUtils.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceUtils.java
@@ -52,7 +52,7 @@ public class DeviceUtils {
 	public static Device getRequiredCurrentDevice(HttpServletRequest request) {
 		Device device = getCurrentDevice(request);
 		if (device == null) {
-			throw new IllegalStateException("No current device is set in this request and one is required - have you configured a DeviceResolvingHandlerInterceptor?");
+			throw new IllegalStateException("No current device is set in this request and one is required - have you configured a DeviceResolverHandlerInterceptor?");
 		}
 		return device;
 	}


### PR DESCRIPTION
Since the DeviceResolvingHandlerInterceptor has been renamed to DeviceResolverHandlerInterceptor, the message should be updated.