### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Very important, before we can accept your Spring Mobile contribution, we will ne
 
 1. go to [https://github.com/spring-projects/spring-mobile](https://github.com/spring-projects/spring-mobile)
 2. hit the "fork" button and choose your own github account as the target
-3. for more detail see [http://help.github.com/fork-a-repo/](http://help.github.com/fork-a-repo/)
+3. for more detail see [https://help.github.com/fork-a-repo/](https://help.github.com/fork-a-repo/)
 
 ## Setup your Local Development Environment
 
@@ -36,7 +36,7 @@ _you should see branches on origin as well as upstream, including 'master'_
 * When ready to resolve an issue or to collaborate with others, you can push your branch to origin (your fork), e.g.: `git push origin MOBILE-123`
 * If you want to collaborate with another contributor, have them fork your repository (add it as a remote) and `git fetch <your-username>` to grab your branch. Alternatively, they can use `git fetch --all` to sync their local state with all of their remotes.
 * If you grant that collaborator push access to your repository, they can even apply their changes to your branch.
-* When ready for your contribution to be reviewed for potential inclusion in the master branch of the canonical spring-mobile repository (what you know as 'upstream'), issue a pull request to the SpringSource repository (for more detail, see [http://help.github.com/send-pull-requests/](http://help.github.com/send-pull-requests/)).
+* When ready for your contribution to be reviewed for potential inclusion in the master branch of the canonical spring-mobile repository (what you know as 'upstream'), issue a pull request to the SpringSource repository (for more detail, see [https://help.github.com/send-pull-requests/](https://help.github.com/send-pull-requests/)).
 * The project lead may merge your changes into the upstream master branch as-is, he may keep the pull request open yet add a comment about something that should be modified, or he might reject the pull request by closing it.
 * A prerequisite for any pull request is that it will be cleanly merge-able with the upstream master's current state. **This is the responsibility of any contributor.** If your pull request cannot be applied cleanly, the project lead will most likely add a comment requesting that you make it merge-able.
 

--- a/README.md
+++ b/README.md
@@ -151,27 +151,27 @@ Follow [@SpringCentral] as well as [@SpringFramework] on Twitter. In-depth artic
 [Spring Mobile] is released under version 2.0 of the [Apache License].
 
 
-[Spring Mobile]: http://projects.spring.io/spring-mobile
-[Spring Framework]: http://projects.spring.io/spring-framework
-[Spring Web MVC]: http://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html
+[Spring Mobile]: https://projects.spring.io/spring-mobile
+[Spring Framework]: https://projects.spring.io/spring-framework
+[Spring Web MVC]: https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html
 [downloading Spring artifacts]: https://github.com/spring-projects/spring-framework/wiki/Downloading-Spring-artifacts
 [building a distribution with dependencies]: https://github.com/spring-projects/spring-framework/wiki/Building-a-distribution-with-dependencies
-[Javadoc]: http://docs.spring.io/spring-mobile/docs/current/api/
-[reference docs]: http://docs.spring.io/spring-mobile/docs/current/reference/html/
+[Javadoc]: https://docs.spring.io/spring-mobile/docs/current/api/
+[reference docs]: https://docs.spring.io/spring-mobile/docs/current/reference/html/
 [samples repository]: https://github.com/spring-projects/spring-mobile-samples
-[Spring forums]: http://forum.spring.io/forum/spring-projects/web/mobile
-[spring-mobile tag]: http://stackoverflow.com/questions/tagged/spring-mobile
-[Stack Overflow]: http://stackoverflow.com/faq
-[spring.io]: http://spring.io
-[guides]: http://spring.io/guides
+[Spring forums]: https://forum.spring.io/forum/spring-projects/web/mobile
+[spring-mobile tag]: https://stackoverflow.com/questions/tagged/spring-mobile
+[Stack Overflow]: https://stackoverflow.com/faq
+[spring.io]: https://spring.io
+[guides]: https://spring.io/guides
 [GitHub issues]: https://github.com/spring-projects/spring-mobile/issues
 [the lifecycle of an issue]: https://github.com/spring-projects/spring-framework/wiki/The-Lifecycle-of-an-Issue
-[Gradle]: http://gradle.org
+[Gradle]: https://gradle.org
 [sts]: https://spring.io/tools
-[Pull requests]: http://help.github.com/send-pull-requests
+[Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: CONTRIBUTING.md
 [@SpringFramework]: https://twitter.com/springframework
 [@SpringCentral]: https://twitter.com/springcentral
-[The Spring Blog]: http://spring.io/blog/
-[news feed]: http://spring.io/blog/category/news
+[The Spring Blog]: https://spring.io/blog/
+[news feed]: https://spring.io/blog/category/news
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/SiteSwitcherAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/SiteSwitcherAutoConfigurationTests.java
@@ -125,7 +125,7 @@ public class SiteSwitcherAutoConfigurationTests {
 			}
 		});
 		interceptor.preHandle(request, response, null);
-		assertThat(response.getRedirectedUrl()).isEqualToIgnoringWhitespace("http://m.app.local");
+		assertThat(response.getRedirectedUrl()).isEqualToIgnoringWhitespace("https://m.app.local");
 	}
 
 	@Configuration

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/LiteDeviceResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/LiteDeviceResolver.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletRequest;
  * 
  * Tablet resolution is also performed based on known tablet browser UA strings. Android
  * tablets are detected based on <a href=
- * "http://googlewebmastercentral.blogspot.com/2011/03/mo-better-to-also-detect-mobile-user.html"
+ * "https://googlewebmastercentral.blogspot.com/2011/03/mo-better-to-also-detect-mobile-user.html"
  * >Google's recommendations</a>.
  * 
  * @author Keith Donald

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptor.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptor.java
@@ -72,8 +72,8 @@ public class SiteSwitcherHandlerInterceptor extends HandlerInterceptorAdapter {
 
 	/**
 	 * Creates a new site switcher.
-	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. http://app.com
-	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. http://m.app.com
+	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. https://app.com
+	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. https://m.app.com
 	 * @param sitePreferenceHandler the handler for the user site preference
 	 */
 	public SiteSwitcherHandlerInterceptor(SiteUrlFactory normalSiteUrlFactory, SiteUrlFactory mobileSiteUrlFactory,
@@ -83,8 +83,8 @@ public class SiteSwitcherHandlerInterceptor extends HandlerInterceptorAdapter {
 
 	/**
 	 * Creates a new site switcher.
-	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. http://app.com
-	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. http://m.app.com 
+	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. https://app.com
+	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. https://m.app.com 
 	 * @param sitePreferenceHandler the handler for the user site preference
 	 * @param tabletIsMobile true to send tablets to the 'mobile' site.
 	 */
@@ -96,9 +96,9 @@ public class SiteSwitcherHandlerInterceptor extends HandlerInterceptorAdapter {
 
 	/**
 	 * Creates a new site switcher.
-	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. http://app.com
-	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. http://m.app.com
-	 * @param tabletSiteUrlFactory the factory for a "tablet" site URL e.g. http://app.com/tablet
+	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. https://app.com
+	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. https://m.app.com
+	 * @param tabletSiteUrlFactory the factory for a "tablet" site URL e.g. https://app.com/tablet
 	 * @param sitePreferenceHandler the handler for the user site preference
 	 */
 	public SiteSwitcherHandlerInterceptor(SiteUrlFactory normalSiteUrlFactory, SiteUrlFactory mobileSiteUrlFactory,
@@ -212,7 +212,7 @@ public class SiteSwitcherHandlerInterceptor extends HandlerInterceptorAdapter {
 	/**
 	 * Creates a site switcher that redirects to a path on the current domain for normal site requests that either
 	 * originate from a mobile device or indicate a mobile site preference.
-	 * Allows you to configure a root path for an application. For example, if your app is running at <code>http://www.domain.com/myapp</code>,
+	 * Allows you to configure a root path for an application. For example, if your app is running at <code>https://www.domain.com/myapp</code>,
 	 * then the root path is <code>/myapp</code>.
 	 * Uses a {@link CookieSitePreferenceRepository} that saves a cookie that is stored on the root path.
 	 */
@@ -223,7 +223,7 @@ public class SiteSwitcherHandlerInterceptor extends HandlerInterceptorAdapter {
 	/**
 	 * Creates a site switcher that redirects to a path on the current domain for normal site requests that either
 	 * originate from a mobile device or tablet device, or indicate a mobile or tablet site preference.
-	 * Allows you to configure a root path for an application. For example, if your app is running at <code>http://www.domain.com/myapp</code>,
+	 * Allows you to configure a root path for an application. For example, if your app is running at <code>https://www.domain.com/myapp</code>,
 	 * then the root path is <code>/myapp</code>.
 	 * Uses a {@link CookieSitePreferenceRepository} that saves a cookie that is stored on the root path.
 	 */

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilter.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilter.java
@@ -156,8 +156,8 @@ public class SiteSwitcherRequestFilter extends OncePerRequestFilter {
 
 	/**
 	 * Creates a new site switcher.
-	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. http://app.com
-	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. http://m.app.com
+	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. https://app.com
+	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. https://m.app.com
 	 * @param tabletSiteUrlFactory the factory for a "tablet" site
 	 * @param sitePreferenceHandler the handler for the user site preference
 	 */

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandler.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandler.java
@@ -44,9 +44,9 @@ public class StandardSiteSwitcherHandler implements SiteSwitcherHandler {
 
 	/**
 	 * Creates a new site switcher handler
-	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. http://app.com
-	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. http://m.app.com
-	 * @param tabletSiteUrlFactory the factory for a "tablet" site URL e.g. http://app.com/tablet
+	 * @param normalSiteUrlFactory the factory for a "normal" site URL e.g. https://app.com
+	 * @param mobileSiteUrlFactory the factory for a "mobile" site URL e.g. https://m.app.com
+	 * @param tabletSiteUrlFactory the factory for a "tablet" site URL e.g. https://app.com/tablet
 	 * @param sitePreferenceHandler the handler for the user site preference
 	 * @param tabletIsMobile true if tablets should be redirected to the mobile site
 	 */

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandlerFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandlerFactory.java
@@ -140,7 +140,7 @@ public class StandardSiteSwitcherHandlerFactory {
 	/**
 	 * Creates a site switcher that redirects to a path on the current domain for normal site requests that either
 	 * originate from a mobile device or indicate a mobile site preference.
-	 * Allows you to configure a root path for an application. For example, if your app is running at <code>http://www.domain.com/myapp</code>,
+	 * Allows you to configure a root path for an application. For example, if your app is running at <code>https://www.domain.com/myapp</code>,
 	 * then the root path is <code>/myapp</code>.
 	 * Uses a {@link CookieSitePreferenceRepository} that saves a cookie that is stored on the root path.
 	 */
@@ -156,7 +156,7 @@ public class StandardSiteSwitcherHandlerFactory {
 	/**
 	 * Creates a site switcher that redirects to a path on the current domain for normal site requests that either
 	 * originate from a mobile device or tablet device, or indicate a mobile or tablet site preference.
-	 * Allows you to configure a root path for an application. For example, if your app is running at <code>http://www.domain.com/myapp</code>,
+	 * Allows you to configure a root path for an application. For example, if your app is running at <code>https://www.domain.com/myapp</code>,
 	 * then the root path is <code>/myapp</code>.
 	 * Uses a {@link CookieSitePreferenceRepository} that saves a cookie that is stored on the root path.
 	 */

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactoryTest.java
@@ -135,91 +135,91 @@ public final class MobileSitePathUrlFactoryTest extends AbstractSitePathUrlFacto
 	public void createRootSiteUrl() {
 		request.setServerPort(80);
 		request.setRequestURI("/bar");
-		assertEquals("http://www.app.com/mobile/bar", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/mobile/bar", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlPort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/bar");
-		assertEquals("http://www.app.com:8080/mobile/bar", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/mobile/bar", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrl() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/bar");
-		assertEquals("http://www.app.com/showcase/mobile/bar", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/mobile/bar", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlPort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/bar");
-		assertEquals("http://www.app.com:8080/showcase/mobile/bar", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/mobile/bar", basicPathFactory.createSiteUrl(request));
 	}
 	
 	@Test
 	public void createPathSiteUrlPort8080withQueryString() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/bar?xval=123&yval=456");
-		assertEquals("http://www.app.com:8080/showcase/mobile/bar?xval=123&yval=456", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/mobile/bar?xval=123&yval=456", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlFromTabletSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/tablet/about");
-		assertEquals("http://www.app.com/mobile/about", advRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/mobile/about", advRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlFromTabletSitePort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/tablet/about");
-		assertEquals("http://www.app.com:8080/mobile/about", advRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/mobile/about", advRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createLongRootSiteUrlFromTabletSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/tablet/about/x/y/z/contact");
-		assertEquals("http://www.app.com/mobile/about/x/y/z/contact", advRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/mobile/about/x/y/z/contact", advRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlFromTabletSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/tablet/about");
-		assertEquals("http://www.app.com/showcase/mobile/about", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/mobile/about", advPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlFromTabletSitePort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/tablet/about");
-		assertEquals("http://www.app.com:8080/showcase/mobile/about", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/mobile/about", advPathFactory.createSiteUrl(request));
 	}
 	
 	@Test
 	public void createPathSiteUrlFromTabletSitePort8080withQueryString() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/tablet/about?x=123");
-		assertEquals("http://www.app.com:8080/showcase/mobile/about?x=123", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/mobile/about?x=123", advPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createLongPathSiteUrlFromTabletSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/tablet/about/x/y/z/contact");
-		assertEquals("http://www.app.com/showcase/mobile/about/x/y/z/contact", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/mobile/about/x/y/z/contact", advPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createLongPathSiteUrlFromTabletSiteMultipleTablet() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/tablet/about/x/y/tablet/z/contact");
-		assertEquals("http://www.app.com/showcase/mobile/about/x/y/tablet/z/contact",
+		assertEquals("https://www.app.com/showcase/mobile/about/x/y/tablet/z/contact",
 				advPathFactory.createSiteUrl(request));
 	}
 
@@ -227,7 +227,7 @@ public final class MobileSitePathUrlFactoryTest extends AbstractSitePathUrlFacto
 	public void createLongPathSiteUrlFromTabletSiteMultipleTabletAndSlashes() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/tablet//about/x/y/tablet///z/contact//");
-		assertEquals("http://www.app.com/showcase/mobile//about/x/y/tablet///z/contact//",
+		assertEquals("https://www.app.com/showcase/mobile//about/x/y/tablet///z/contact//",
 				advPathFactory.createSiteUrl(request));
 	}
 

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactoryTest.java
@@ -136,56 +136,56 @@ public final class NormalSitePathUrlFactoryTest extends AbstractSitePathUrlFacto
 	public void createRootSiteUrlMobile() {
 		request.setServerPort(80);
 		request.setRequestURI("/mob/foo");
-		assertEquals("http://www.app.com/foo", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/foo", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlTablet() {
 		request.setServerPort(80);
 		request.setRequestURI("/tab/foo");
-		assertEquals("http://www.app.com/foo", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/foo", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlMobilePort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/mob/foo");
-		assertEquals("http://www.app.com:8080/foo", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/foo", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlTabletPort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/tab/foo");
-		assertEquals("http://www.app.com:8080/foo", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/foo", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlMobile() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/mob/foo");
-		assertEquals("http://www.app.com/showcase/foo", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/foo", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlTablet() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/tab/foo");
-		assertEquals("http://www.app.com/showcase/foo", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/foo", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlMobilePort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/mob/foo");
-		assertEquals("http://www.app.com:8080/showcase/foo", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/foo", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlTabletPort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/tab/foo");
-		assertEquals("http://www.app.com:8080/showcase/foo", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/foo", basicPathFactory.createSiteUrl(request));
 	}
 
 }

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/ServerNameSiteUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/ServerNameSiteUrlFactoryTest.java
@@ -46,7 +46,7 @@ public class ServerNameSiteUrlFactoryTest {
 		request.setServerName("m.app.com");
 		request.setServerPort(80);
 		request.setRequestURI("/foo");
-		assertEquals("http://m.app.com/foo", factory.createSiteUrl(request));
+		assertEquals("https://m.app.com/foo", factory.createSiteUrl(request));
 	}
 
 }

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptorTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptorTest.java
@@ -57,7 +57,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 			}
 
 			public String createSiteUrl(HttpServletRequest request) {
-				return "http://app.com";
+				return "https://app.com";
 			}
 		};
 		SiteUrlFactory mobileSiteUrlFactory = new SiteUrlFactory() {
@@ -66,7 +66,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 			}
 
 			public String createSiteUrl(HttpServletRequest request) {
-				return "http://m.app.com";
+				return "https://m.app.com";
 			}
 		};
 		SiteUrlFactory tabletSiteUrlFactory = new SiteUrlFactory() {
@@ -75,7 +75,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 			}
 
 			public String createSiteUrl(HttpServletRequest request) {
-				return "http://app.com/tab";
+				return "https://app.com/tab";
 			}
 		};
 		SitePreferenceHandler sitePreferenceHandler = new StandardSitePreferenceHandler(sitePreferenceRepository);
@@ -103,7 +103,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.NORMAL);
 		sitePreferenceRepository.setSitePreference(SitePreference.MOBILE);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -111,14 +111,14 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.NORMAL);
 		sitePreferenceRepository.setSitePreference(SitePreference.TABLET);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://app.com/tab", response.getRedirectedUrl());
+		assertEquals("https://app.com/tab", response.getRedirectedUrl());
 	}
 
 	@Test
 	public void mobileDeviceNoPreference() throws Exception {
 		device.setDeviceType(DeviceType.MOBILE);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -126,7 +126,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		sitePreferenceRepository.setSitePreference(SitePreference.MOBILE);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -142,14 +142,14 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		sitePreferenceRepository.setSitePreference(SitePreference.TABLET);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://app.com/tab", response.getRedirectedUrl());
+		assertEquals("https://app.com/tab", response.getRedirectedUrl());
 	}
 
 	@Test
 	public void tabletDeviceNoPreference() throws Exception {
 		device.setDeviceType(DeviceType.TABLET);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://app.com/tab", response.getRedirectedUrl());
+		assertEquals("https://app.com/tab", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -157,7 +157,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.TABLET);
 		sitePreferenceRepository.setSitePreference(SitePreference.MOBILE);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -173,7 +173,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.TABLET);
 		sitePreferenceRepository.setSitePreference(SitePreference.TABLET);
 		assertFalse(siteSwitcher.preHandle(request, response, null));
-		assertEquals("http://app.com/tab", response.getRedirectedUrl());
+		assertEquals("https://app.com/tab", response.getRedirectedUrl());
 	}
 
 	// mDot tests
@@ -194,7 +194,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor mDot = SiteSwitcherHandlerInterceptor.mDot("app.com");
 		assertFalse(mDot.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -219,7 +219,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -231,7 +231,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -278,7 +278,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor mDot = SiteSwitcherHandlerInterceptor.mDot("app.com");
 		assertFalse(mDot.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -288,7 +288,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor mDot = SiteSwitcherHandlerInterceptor.mDot("app.com");
 		assertFalse(mDot.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com?city=Z%C3%BCrich", response.getRedirectedUrl());
+		assertEquals("https://m.app.com?city=Z%C3%BCrich", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -323,7 +323,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -335,7 +335,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -373,7 +373,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("TABLET", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -392,7 +392,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor mDot = SiteSwitcherHandlerInterceptor.mDot("app.com");
 		assertFalse(mDot.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -417,7 +417,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -429,7 +429,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -467,7 +467,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("TABLET", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -476,7 +476,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor mDot = SiteSwitcherHandlerInterceptor.mDot("app.com", true);
 		assertFalse(mDot.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -486,7 +486,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor mDot = SiteSwitcherHandlerInterceptor.mDot("app.com", true);
 		assertFalse(mDot.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com?x=123", response.getRedirectedUrl());
+		assertEquals("https://m.app.com?x=123", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -521,7 +521,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -533,7 +533,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -558,7 +558,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("TABLET", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -592,7 +592,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor dotMobi = SiteSwitcherHandlerInterceptor.dotMobi("app.com");
 		assertFalse(dotMobi.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -603,7 +603,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor dotMobi = SiteSwitcherHandlerInterceptor.dotMobi("app.com");
 		assertFalse(dotMobi.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://app.com?x=123", response.getRedirectedUrl());
+		assertEquals("https://app.com?x=123", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -628,7 +628,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -732,7 +732,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -776,7 +776,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		SiteSwitcherHandlerInterceptor dotMobi = SiteSwitcherHandlerInterceptor.dotMobi("app.com");
 		assertFalse(dotMobi.preHandle(request, response, null));
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -801,7 +801,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -851,7 +851,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("TABLET", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -905,7 +905,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("NORMAL", response.getCookies()[0].getValue());
-		assertEquals("http://app.com", response.getRedirectedUrl());
+		assertEquals("https://app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1000,7 +1000,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://mobile.com", response.getRedirectedUrl());
+		assertEquals("https://www.att.com/", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1008,7 +1008,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "tablet.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://mobile.com", response.getRedirectedUrl());
+		assertEquals("https://www.att.com/", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1017,7 +1017,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		request.setServerName("normal.com");
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "tablet.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://mobile.com", response.getRedirectedUrl());
+		assertEquals("https://www.att.com/", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1035,7 +1035,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		request.setServerName("tablet.com");
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "tablet.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://mobile.com", response.getRedirectedUrl());
+		assertEquals("https://www.att.com/", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1043,7 +1043,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		device.setDeviceType(DeviceType.TABLET);
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "tablet.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://tablet.com", response.getRedirectedUrl());
+		assertEquals("https://www.salesforce.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1052,7 +1052,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		request.setServerName("normal.com");
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "tablet.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://tablet.com", response.getRedirectedUrl());
+		assertEquals("https://www.salesforce.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -1061,7 +1061,7 @@ public class SiteSwitcherHandlerInterceptorTest {
 		request.setServerName("mobile.com");
 		SiteSwitcherHandlerInterceptor interceptor = SiteSwitcherHandlerInterceptor.standard("normal.com", "mobile.com", "tablet.com", "." + "normal.com");
 		assertFalse(interceptor.preHandle(request, response, null));
-		assertEquals("http://tablet.com", response.getRedirectedUrl());
+		assertEquals("https://www.salesforce.com", response.getRedirectedUrl());
 	}
 
 	@Test

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilterTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilterTest.java
@@ -73,7 +73,7 @@ public class SiteSwitcherRequestFilterTest {
 			}
 
 			public String createSiteUrl(HttpServletRequest request) {
-				return "http://app.com";
+				return "https://app.com";
 			}
 		};
 		SiteUrlFactory mobileSiteUrlFactory = new SiteUrlFactory() {
@@ -82,7 +82,7 @@ public class SiteSwitcherRequestFilterTest {
 			}
 
 			public String createSiteUrl(HttpServletRequest request) {
-				return "http://m.app.com";
+				return "https://m.app.com";
 			}
 		};
 		SiteUrlFactory tabletSiteUrlFactory = new SiteUrlFactory() {
@@ -91,7 +91,7 @@ public class SiteSwitcherRequestFilterTest {
 			}
 
 			public String createSiteUrl(HttpServletRequest request) {
-				return "http://app.com/t";
+				return "https://app.com/t";
 			}
 		};
 		SitePreferenceHandler sitePreferenceHandler = new StandardSitePreferenceHandler(sitePreferenceRepository);
@@ -120,7 +120,7 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.NORMAL);
 		sitePreferenceRepository.setSitePreference(SitePreference.MOBILE);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -128,14 +128,14 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.NORMAL);
 		sitePreferenceRepository.setSitePreference(SitePreference.TABLET);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://app.com/t", response.getRedirectedUrl());
+		assertEquals("https://app.com/t", response.getRedirectedUrl());
 	}
 
 	@Test
 	public void mobileDeviceNoPreference() throws Exception {
 		device.setDeviceType(DeviceType.MOBILE);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -151,7 +151,7 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		sitePreferenceRepository.setSitePreference(SitePreference.MOBILE);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -159,14 +159,14 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		sitePreferenceRepository.setSitePreference(SitePreference.TABLET);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://app.com/t", response.getRedirectedUrl());
+		assertEquals("https://app.com/t", response.getRedirectedUrl());
 	}
 
 	@Test
 	public void tabletDeviceNoPreference() throws Exception {
 		device.setDeviceType(DeviceType.TABLET);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://app.com/t", response.getRedirectedUrl());
+		assertEquals("https://app.com/t", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -182,7 +182,7 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.TABLET);
 		sitePreferenceRepository.setSitePreference(SitePreference.MOBILE);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -190,7 +190,7 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.TABLET);
 		sitePreferenceRepository.setSitePreference(SitePreference.TABLET);
 		siteSwitcher.doFilter(request, response, filterChain);
-		assertEquals("http://app.com/t", response.getRedirectedUrl());
+		assertEquals("https://app.com/t", response.getRedirectedUrl());
 	}
 
 	@Test(expected = ServletException.class)
@@ -254,7 +254,7 @@ public class SiteSwitcherRequestFilterTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -273,7 +273,7 @@ public class SiteSwitcherRequestFilterTest {
 		device.setDeviceType(DeviceType.MOBILE);
 		filterTest("mDot");
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 	
 	@Test
@@ -282,7 +282,7 @@ public class SiteSwitcherRequestFilterTest {
 		request.setQueryString(UriUtils.encodeQuery("city=Z\u00fcrich", "UTF-8"));
 		filterTest("mDot");
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com?city=Z%C3%BCrich", response.getRedirectedUrl());
+		assertEquals("https://m.app.com?city=Z%C3%BCrich", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -304,7 +304,7 @@ public class SiteSwitcherRequestFilterTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -345,7 +345,7 @@ public class SiteSwitcherRequestFilterTest {
 		assertEquals(1, response.getCookies().length);
 		assertEquals(".app.com", response.getCookies()[0].getDomain());
 		assertEquals("MOBILE", response.getCookies()[0].getValue());
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -384,7 +384,7 @@ public class SiteSwitcherRequestFilterTest {
 		mDot.init(filterConfig);
 		mDot.doFilter(request, response, filterChain);
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	@Test
@@ -398,7 +398,7 @@ public class SiteSwitcherRequestFilterTest {
 		mDot.init(filterConfig);
 		mDot.doFilter(request, response, filterChain);
 		assertEquals(0, response.getCookies().length);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 	}
 
 	// dotMobi tests
@@ -889,7 +889,7 @@ public class SiteSwitcherRequestFilterTest {
 		MockFilter otherFilter = new MockFilter(servlet);
 		MockFilterChain chain = new MockFilterChain(servlet, siteSwitcher, otherFilter);
 		chain.doFilter(this.request, this.response);
-		assertEquals("http://m.app.com", response.getRedirectedUrl());
+		assertEquals("https://m.app.com", response.getRedirectedUrl());
 		assertFalse(otherFilter.invoked);
 		verify(servlet);
 	}

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/TabletSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/TabletSitePathUrlFactoryTest.java
@@ -115,77 +115,77 @@ public final class TabletSitePathUrlFactoryTest extends AbstractSitePathUrlFacto
 	public void createRootSiteUrl() {
 		request.setServerPort(80);
 		request.setRequestURI("/bar");
-		assertEquals("http://www.app.com/tablet/bar", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/tablet/bar", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlPort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/bar");
-		assertEquals("http://www.app.com:8080/tablet/bar", basicRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/tablet/bar", basicRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrl() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/bar");
-		assertEquals("http://www.app.com/showcase/tablet/bar", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/tablet/bar", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlPort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/bar");
-		assertEquals("http://www.app.com:8080/showcase/tablet/bar", basicPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/tablet/bar", basicPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlFromMobileSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/mobile/about");
-		assertEquals("http://www.app.com/tablet/about", advRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/tablet/about", advRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createRootSiteUrlFromMobileSitePort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/mobile/about");
-		assertEquals("http://www.app.com:8080/tablet/about", advRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/tablet/about", advRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createLongRootSiteUrlFromMobileSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/mobile/about/x/y/z/contact");
-		assertEquals("http://www.app.com/tablet/about/x/y/z/contact", advRootFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/tablet/about/x/y/z/contact", advRootFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlFromMobileSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/mobile/about");
-		assertEquals("http://www.app.com/showcase/tablet/about", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/tablet/about", advPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createPathSiteUrlFromMobileSitePort8080() {
 		request.setServerPort(8080);
 		request.setRequestURI("/showcase/mobile/about");
-		assertEquals("http://www.app.com:8080/showcase/tablet/about", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com:8080/showcase/tablet/about", advPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createLongPathSiteUrlFromMobileSite() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/mobile/about/x/y/z/contact");
-		assertEquals("http://www.app.com/showcase/tablet/about/x/y/z/contact", advPathFactory.createSiteUrl(request));
+		assertEquals("https://www.app.com/showcase/tablet/about/x/y/z/contact", advPathFactory.createSiteUrl(request));
 	}
 
 	@Test
 	public void createLongPathSiteUrlFromMobileSiteMultipleMobile() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/mobile/about/x/mobile/y/z/contact");
-		assertEquals("http://www.app.com/showcase/tablet/about/x/mobile/y/z/contact",
+		assertEquals("https://www.app.com/showcase/tablet/about/x/mobile/y/z/contact",
 				advPathFactory.createSiteUrl(request));
 	}
 
@@ -193,7 +193,7 @@ public final class TabletSitePathUrlFactoryTest extends AbstractSitePathUrlFacto
 	public void createLongPathSiteUrlFromMobileSiteMultipleMobileAndSlashes() {
 		request.setServerPort(80);
 		request.setRequestURI("/showcase/mobile/about//x/mobile////y/z/contact///");
-		assertEquals("http://www.app.com/showcase/tablet/about//x/mobile////y/z/contact///",
+		assertEquals("https://www.app.com/showcase/tablet/about//x/mobile////y/z/contact///",
 				advPathFactory.createSiteUrl(request));
 	}
 

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/MdotSiteSwitcherAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/MdotSiteSwitcherAnnotationTest.java
@@ -59,7 +59,7 @@ public class MdotSiteSwitcherAnnotationTest {
 			}
 		});
 		interceptor.preHandle(request, response, null);
-		assertThat(response.getRedirectedUrl()).isEqualToIgnoringWhitespace("http://m.server.local");
+		assertThat(response.getRedirectedUrl()).isEqualToIgnoringWhitespace("https://m.server.local");
 	}
 
 }

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/view/LiteDeviceDelegatingViewResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/view/LiteDeviceDelegatingViewResolverTest.java
@@ -99,8 +99,8 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameNoDeviceNoSitePreferenceRedirectAbsoluteUrl() throws Exception {
-		this.viewName = "redirect:http://spring.io";
-		replayMocks("redirect:http://spring.io");
+		this.viewName = "redirect:https://spring.io";
+		replayMocks("redirect:https://spring.io");
 	}
 	
 	@Test
@@ -123,8 +123,8 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameNoDeviceNoSitePreferenceForwardAbsoluteUrl() throws Exception {
-		this.viewName = "forward:http://spring.io";
-		replayMocks("forward:http://spring.io");
+		this.viewName = "forward:https://spring.io";
+		replayMocks("forward:https://spring.io");
 	}
 
 	@Test
@@ -156,11 +156,11 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameNormalDeviceNormalPrefixRedirectToAbsoluteUrl() throws Exception {
-		this.viewName = "redirect:http://spring.io";
+		this.viewName = "redirect:https://spring.io";
 		device.setDeviceType(DeviceType.NORMAL);
 		request.setAttribute(DeviceUtils.CURRENT_DEVICE_ATTRIBUTE, device);
 		viewResolver.setNormalPrefix("normal/");
-		replayMocks("redirect:http://spring.io");
+		replayMocks("redirect:https://spring.io");
 	}
 	
 	@Test
@@ -210,11 +210,11 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameNormalDeviceNormalPrefixForwardToAbsoluteUrl() throws Exception {
-		this.viewName = "forward:http://spring.io";
+		this.viewName = "forward:https://spring.io";
 		device.setDeviceType(DeviceType.NORMAL);
 		request.setAttribute(DeviceUtils.CURRENT_DEVICE_ATTRIBUTE, device);
 		viewResolver.setNormalPrefix("normal/");
-		replayMocks("forward:http://spring.io");
+		replayMocks("forward:https://spring.io");
 	}
 
 	@Test
@@ -246,11 +246,11 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameMobileDeviceNormalPrefixRedirectToAbsoluteUrl() throws Exception {
-		this.viewName = "redirect:http://spring.io";
+		this.viewName = "redirect:https://spring.io";
 		device.setDeviceType(DeviceType.MOBILE);
 		request.setAttribute(DeviceUtils.CURRENT_DEVICE_ATTRIBUTE, device);
 		viewResolver.setMobilePrefix("mobile/");
-		replayMocks("redirect:http://spring.io");
+		replayMocks("redirect:https://spring.io");
 	}
 	
 	@Test
@@ -336,11 +336,11 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameTabletDeviceNormalPrefixRedirectToAbsoluteUrl() throws Exception {
-		this.viewName = "redirect:http://spring.io";
+		this.viewName = "redirect:https://spring.io";
 		device.setDeviceType(DeviceType.TABLET);
 		request.setAttribute(DeviceUtils.CURRENT_DEVICE_ATTRIBUTE, device);
 		viewResolver.setTabletPrefix("tablet/");
-		replayMocks("redirect:http://spring.io");
+		replayMocks("redirect:https://spring.io");
 	}
 
 	@Test
@@ -381,11 +381,11 @@ public final class LiteDeviceDelegatingViewResolverTest {
 	
 	@Test
 	public void resolveViewNameTabletDeviceNormalPrefixForwardToAbsoluteUrl() throws Exception {
-		this.viewName = "forward:http://spring.io";
+		this.viewName = "forward:https://spring.io";
 		device.setDeviceType(DeviceType.TABLET);
 		request.setAttribute(DeviceUtils.CURRENT_DEVICE_ATTRIBUTE, device);
 		viewResolver.setTabletPrefix("tablet/");
-		replayMocks("forward:http://spring.io");
+		replayMocks("forward:https://spring.io");
 	}
 
 	@Test

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -2,6 +2,6 @@
 <body>
 <p>This document is the API specification for Spring Mobile.</p>
 <p>For additional developer documentation, please refer to the Spring Mobile reference manual. That manual contains detailed, developer-targeted descriptions, with conceptual overviews, definitions of terms, workarounds, and code examples.</p>
-<p>If you are interested in commercial support for Spring Mobile, please visit http://www.spring.io.</p>
+<p>If you are interested in commercial support for Spring Mobile, please visit https://www.spring.io.</p>
 </body>
 </html>

--- a/src/dist/readme.txt
+++ b/src/dist/readme.txt
@@ -6,6 +6,6 @@ application development.
 
 Please consult the documentation located within the 'docs/reference' directory
 of this release and also visit the official Spring Mobile home at:
-http://projects.spring.io/spring-mobile/
+https://projects.spring.io/spring-mobile/
 
 There you will find links to the issue tracker, samples, and other resources.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://app.mobi (200) with 13 occurrences could not be migrated:  
   ([https](https://app.mobi) result SSLHandshakeException).
* [ ] http://app.mobi?x=123 (200) with 2 occurrences could not be migrated:  
   ([https](https://app.mobi?x=123) result SSLHandshakeException).
* [ ] http://nds.nokia.com/uaprof/N3650r100.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://nds.nokia.com/uaprof/N3650r100.xml) result SSLHandshakeException).
* [ ] http://normal.com (200) with 2 occurrences could not be migrated:  
   ([https](https://normal.com) result AnnotatedConnectException).
* [ ] http://wap.samsungmobile.com/uaprof/GT-I9100.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://wap.samsungmobile.com/uaprof/GT-I9100.xml) result AnnotatedConnectException).
* [ ] http://wap.samsungmobile.com/uaprof/GT-I9300.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://wap.samsungmobile.com/uaprof/GT-I9300.xml) result AnnotatedConnectException).
* [ ] http://wap.samsungmobile.com/uaprof/GT-I9500.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://wap.samsungmobile.com/uaprof/GT-I9500.xml) result AnnotatedConnectException).
* [ ] http://wap.samsungmobile.com/uaprof/GT-P1000.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://wap.samsungmobile.com/uaprof/GT-P1000.xml) result AnnotatedConnectException).
* [ ] http://wap.samsungmobile.com/uaprof/GT-P7310.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://wap.samsungmobile.com/uaprof/GT-P7310.xml) result AnnotatedConnectException).
* [ ] http://wap.samsungmobile.com/uaprof/GT-P7510.xml (200) with 1 occurrences could not be migrated:  
   ([https](https://wap.samsungmobile.com/uaprof/GT-P7510.xml) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://mobile.com (301) with 4 occurrences migrated to:  
  https://www.att.com/ ([https](https://mobile.com) result SSLHandshakeException).
* [ ] http://www.app.com:8080/foo (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.app.com:8080/foo ([https](https://www.app.com:8080/foo) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/mobile/about (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/mobile/about ([https](https://www.app.com:8080/mobile/about) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/mobile/bar (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/mobile/bar ([https](https://www.app.com:8080/mobile/bar) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/foo (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.app.com:8080/showcase/foo ([https](https://www.app.com:8080/showcase/foo) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/mobile/about (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/showcase/mobile/about ([https](https://www.app.com:8080/showcase/mobile/about) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/mobile/about?x=123 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/showcase/mobile/about?x=123 ([https](https://www.app.com:8080/showcase/mobile/about?x=123) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/mobile/bar (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/showcase/mobile/bar ([https](https://www.app.com:8080/showcase/mobile/bar) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/mobile/bar?xval=123&yval=456 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/showcase/mobile/bar?xval=123&yval=456 ([https](https://www.app.com:8080/showcase/mobile/bar?xval=123&yval=456) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/tablet/about (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/showcase/tablet/about ([https](https://www.app.com:8080/showcase/tablet/about) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/showcase/tablet/bar (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/showcase/tablet/bar ([https](https://www.app.com:8080/showcase/tablet/bar) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/tablet/about (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/tablet/about ([https](https://www.app.com:8080/tablet/about) result ConnectTimeoutException).
* [ ] http://www.app.com:8080/tablet/bar (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.app.com:8080/tablet/bar ([https](https://www.app.com:8080/tablet/bar) result ConnectTimeoutException).
* [ ] http://m.app.com (UnknownHostException) with 29 occurrences migrated to:  
  https://m.app.com ([https](https://m.app.com) result UnknownHostException).
* [ ] http://m.app.com/foo (UnknownHostException) with 1 occurrences migrated to:  
  https://m.app.com/foo ([https](https://m.app.com/foo) result UnknownHostException).
* [ ] http://m.app.com?city=Z%C3%BCrich (UnknownHostException) with 2 occurrences migrated to:  
  https://m.app.com?city=Z%C3%BCrich ([https](https://m.app.com?city=Z%C3%BCrich) result UnknownHostException).
* [ ] http://m.app.com?x=123 (UnknownHostException) with 1 occurrences migrated to:  
  https://m.app.com?x=123 ([https](https://m.app.com?x=123) result UnknownHostException).
* [ ] http://m.app.local (UnknownHostException) with 1 occurrences migrated to:  
  https://m.app.local ([https](https://m.app.local) result UnknownHostException).
* [ ] http://m.server.local (UnknownHostException) with 1 occurrences migrated to:  
  https://m.server.local ([https](https://m.server.local) result UnknownHostException).
* [ ] http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).
* [ ] http://www.domain.com/myapp (301) with 4 occurrences migrated to:  
  https://www.domain.com/myapp ([https](https://www.domain.com/myapp) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-mobile/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-mobile/docs/current/api/ ([https](https://docs.spring.io/spring-mobile/docs/current/api/) result 200).
* [ ] http://docs.spring.io/spring-mobile/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-mobile/docs/current/reference/html/ ([https](https://docs.spring.io/spring-mobile/docs/current/reference/html/) result 200).
* [ ] http://gradle.org with 1 occurrences migrated to:  
  https://gradle.org ([https](https://gradle.org) result 200).
* [ ] http://projects.spring.io/spring-mobile/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-mobile/ ([https](https://projects.spring.io/spring-mobile/) result 200).
* [ ] http://spring.io with 15 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/blog/ with 1 occurrences migrated to:  
  https://spring.io/blog/ ([https](https://spring.io/blog/) result 200).
* [ ] http://spring.io/blog/category/news with 1 occurrences migrated to:  
  https://spring.io/blog/category/news ([https](https://spring.io/blog/category/news) result 200).
* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://stackoverflow.com/faq with 1 occurrences migrated to:  
  https://stackoverflow.com/faq ([https](https://stackoverflow.com/faq) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-mobile with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-mobile ([https](https://stackoverflow.com/questions/tagged/spring-mobile) result 200).
* [ ] http://tablet.com (301) with 3 occurrences migrated to:  
  https://www.salesforce.com ([https](https://tablet.com) result 200).
* [ ] http://app.com with 22 occurrences migrated to:  
  https://app.com ([https](https://app.com) result 301).
* [ ] http://app.com/t with 5 occurrences migrated to:  
  https://app.com/t ([https](https://app.com/t) result 301).
* [ ] http://app.com/tab with 5 occurrences migrated to:  
  https://app.com/tab ([https](https://app.com/tab) result 301).
* [ ] http://app.com/tablet with 2 occurrences migrated to:  
  https://app.com/tablet ([https](https://app.com/tablet) result 301).
* [ ] http://app.com?x=123 with 1 occurrences migrated to:  
  https://app.com?x=123 ([https](https://app.com?x=123) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html) result 301).
* [ ] http://forum.spring.io/forum/spring-projects/web/mobile with 1 occurrences migrated to:  
  https://forum.spring.io/forum/spring-projects/web/mobile ([https](https://forum.spring.io/forum/spring-projects/web/mobile) result 301).
* [ ] http://googlewebmastercentral.blogspot.com/2011/03/mo-better-to-also-detect-mobile-user.html with 1 occurrences migrated to:  
  https://googlewebmastercentral.blogspot.com/2011/03/mo-better-to-also-detect-mobile-user.html ([https](https://googlewebmastercentral.blogspot.com/2011/03/mo-better-to-also-detect-mobile-user.html) result 301).
* [ ] http://help.github.com/fork-a-repo/ with 2 occurrences migrated to:  
  https://help.github.com/fork-a-repo/ ([https](https://help.github.com/fork-a-repo/) result 301).
* [ ] http://help.github.com/send-pull-requests/ with 2 occurrences migrated to:  
  https://help.github.com/send-pull-requests/ ([https](https://help.github.com/send-pull-requests/) result 301).
* [ ] http://projects.spring.io/spring-framework with 1 occurrences migrated to:  
  https://projects.spring.io/spring-framework ([https](https://projects.spring.io/spring-framework) result 301).
* [ ] http://projects.spring.io/spring-mobile with 1 occurrences migrated to:  
  https://projects.spring.io/spring-mobile ([https](https://projects.spring.io/spring-mobile) result 301).
* [ ] http://www.app.com/foo with 2 occurrences migrated to:  
  https://www.app.com/foo ([https](https://www.app.com/foo) result 301).
* [ ] http://www.app.com/mobile/about with 1 occurrences migrated to:  
  https://www.app.com/mobile/about ([https](https://www.app.com/mobile/about) result 301).
* [ ] http://www.app.com/mobile/about/x/y/z/contact with 1 occurrences migrated to:  
  https://www.app.com/mobile/about/x/y/z/contact ([https](https://www.app.com/mobile/about/x/y/z/contact) result 301).
* [ ] http://www.app.com/mobile/bar with 1 occurrences migrated to:  
  https://www.app.com/mobile/bar ([https](https://www.app.com/mobile/bar) result 301).
* [ ] http://www.app.com/showcase/foo with 2 occurrences migrated to:  
  https://www.app.com/showcase/foo ([https](https://www.app.com/showcase/foo) result 301).
* [ ] http://www.app.com/showcase/mobile//about/x/y/tablet///z/contact// with 1 occurrences migrated to:  
  https://www.app.com/showcase/mobile//about/x/y/tablet///z/contact// ([https](https://www.app.com/showcase/mobile//about/x/y/tablet///z/contact//) result 301).
* [ ] http://www.app.com/showcase/mobile/about with 1 occurrences migrated to:  
  https://www.app.com/showcase/mobile/about ([https](https://www.app.com/showcase/mobile/about) result 301).
* [ ] http://www.app.com/showcase/mobile/about/x/y/tablet/z/contact with 1 occurrences migrated to:  
  https://www.app.com/showcase/mobile/about/x/y/tablet/z/contact ([https](https://www.app.com/showcase/mobile/about/x/y/tablet/z/contact) result 301).
* [ ] http://www.app.com/showcase/mobile/about/x/y/z/contact with 1 occurrences migrated to:  
  https://www.app.com/showcase/mobile/about/x/y/z/contact ([https](https://www.app.com/showcase/mobile/about/x/y/z/contact) result 301).
* [ ] http://www.app.com/showcase/mobile/bar with 1 occurrences migrated to:  
  https://www.app.com/showcase/mobile/bar ([https](https://www.app.com/showcase/mobile/bar) result 301).
* [ ] http://www.app.com/showcase/tablet/about with 1 occurrences migrated to:  
  https://www.app.com/showcase/tablet/about ([https](https://www.app.com/showcase/tablet/about) result 301).
* [ ] http://www.app.com/showcase/tablet/about//x/mobile////y/z/contact/// with 1 occurrences migrated to:  
  https://www.app.com/showcase/tablet/about//x/mobile////y/z/contact/// ([https](https://www.app.com/showcase/tablet/about//x/mobile////y/z/contact///) result 301).
* [ ] http://www.app.com/showcase/tablet/about/x/mobile/y/z/contact with 1 occurrences migrated to:  
  https://www.app.com/showcase/tablet/about/x/mobile/y/z/contact ([https](https://www.app.com/showcase/tablet/about/x/mobile/y/z/contact) result 301).
* [ ] http://www.app.com/showcase/tablet/about/x/y/z/contact with 1 occurrences migrated to:  
  https://www.app.com/showcase/tablet/about/x/y/z/contact ([https](https://www.app.com/showcase/tablet/about/x/y/z/contact) result 301).
* [ ] http://www.app.com/showcase/tablet/bar with 1 occurrences migrated to:  
  https://www.app.com/showcase/tablet/bar ([https](https://www.app.com/showcase/tablet/bar) result 301).
* [ ] http://www.app.com/tablet/about with 1 occurrences migrated to:  
  https://www.app.com/tablet/about ([https](https://www.app.com/tablet/about) result 301).
* [ ] http://www.app.com/tablet/about/x/y/z/contact with 1 occurrences migrated to:  
  https://www.app.com/tablet/about/x/y/z/contact ([https](https://www.app.com/tablet/about/x/y/z/contact) result 301).
* [ ] http://www.app.com/tablet/bar with 1 occurrences migrated to:  
  https://www.app.com/tablet/bar ([https](https://www.app.com/tablet/bar) result 301).
* [ ] http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).