### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Follow [@SpringCentral] as well as [@SpringFramework] on Twitter. In-depth artic
 [@SpringCentral]: https://twitter.com/springcentral
 [The Spring Blog]: https://spring.io/blog/
 [news feed]: https://spring.io/blog/category/news
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverAutoConfiguration.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverFactory.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverProperties.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceResolverAutoConfiguration.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/DeviceResolverAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/SitePreferenceAutoConfiguration.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/SitePreferenceAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/SiteSwitcherAutoConfiguration.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/SiteSwitcherAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/package-info.java
+++ b/spring-mobile-autoconfigure/src/main/java/org/springframework/mobile/autoconfigure/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/AbstractDeviceResolverAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/AbstractDeviceResolverAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/AbstractSitePreferenceAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/AbstractSitePreferenceAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/CustomDeviceResolverAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/CustomDeviceResolverAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/CustomSitePreferenceAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/CustomSitePreferenceAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/DeviceDelegatingViewResolverAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/DeviceResolverAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/DeviceResolverAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/SitePreferenceAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/SitePreferenceAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/SiteSwitcherAutoConfigurationTests.java
+++ b/spring-mobile-autoconfigure/src/test/java/org/springframework/mobile/autoconfigure/SiteSwitcherAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/Device.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/Device.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceHandlerMethodArgumentResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DevicePlatform.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DevicePlatform.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceResolverHandlerInterceptor.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceResolverHandlerInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceResolverRequestFilter.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceResolverRequestFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceType.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceUtils.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceWebArgumentResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/DeviceWebArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/LiteDevice.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/LiteDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/LiteDeviceResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/LiteDeviceResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/DeviceResolverConfiguration.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/DeviceResolverConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/DeviceResolverConfigurer.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/DeviceResolverConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/EnableDeviceResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/EnableDeviceResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/package-info.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/annotation/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/package-info.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/CookieSitePreferenceRepository.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/CookieSitePreferenceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreference.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceHandler.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceHandlerInterceptor.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceHandlerInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceHandlerMethodArgumentResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceRepository.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceRequestFilter.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceRequestFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceUtils.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceWebArgumentResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/SitePreferenceWebArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/StandardSitePreferenceHandler.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/StandardSitePreferenceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/EnableSitePreference.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/EnableSitePreference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/SitePreferenceConfiguration.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/SitePreferenceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/SitePreferenceConfigurer.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/SitePreferenceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/package-info.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/annotation/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/package-info.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/site/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSiteUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/AbstractSiteUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandler.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptor.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilter.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/SiteUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandler.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandlerFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteSwitcherHandlerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/StandardSiteUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/TabletSitePathUrlFactory.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/TabletSitePathUrlFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/EnableSiteSwitcher.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/EnableSiteSwitcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/SiteSwitcherConfiguration.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/SiteSwitcherConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/SiteSwitcherConfigurer.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/SiteSwitcherConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/package-info.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/switcher/annotation/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/util/ResolverUtils.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/util/ResolverUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/util/package-info.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/util/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/view/AbstractDeviceDelegatingViewResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/view/AbstractDeviceDelegatingViewResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/main/java/org/springframework/mobile/device/view/LiteDeviceDelegatingViewResolver.java
+++ b/spring-mobile-device/src/main/java/org/springframework/mobile/device/view/LiteDeviceDelegatingViewResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceHandlerMethodArgumentResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceHandlerMethodArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceResolverHandlerInterceptorTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceResolverHandlerInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceResolverRequestFilterTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceResolverRequestFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceWebArgumentResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/DeviceWebArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/LiteDeviceResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/LiteDeviceResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/LiteDeviceTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/LiteDeviceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/StubDevice.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/StubDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/UserAgent.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/UserAgent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/AlwaysIphoneDeviceResolverAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/AlwaysIphoneDeviceResolverAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/AlwaysIphoneDeviceResolverConfiguration.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/AlwaysIphoneDeviceResolverConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/DefaultDeviceResolverAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/DefaultDeviceResolverAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/DefaultDeviceResolverConfiguration.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/annotation/DefaultDeviceResolverConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/CookieSitePreferenceRepositoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/CookieSitePreferenceRepositoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceHandlerInterceptorTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceHandlerInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceHandlerMethodArgumentResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceHandlerMethodArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceRequestFilterTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceRequestFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceWebArgumentResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/SitePreferenceWebArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/StandardSitePreferenceHandlerTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/StandardSitePreferenceHandlerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/StubSitePreferenceRepository.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/StubSitePreferenceRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/AlwaysMobileSitePreferenceAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/AlwaysMobileSitePreferenceAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/AlwaysMobileSitePreferenceConfiguration.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/AlwaysMobileSitePreferenceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/DefaultSitePreferenceAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/DefaultSitePreferenceAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/DefaultSitePreferenceConfiguration.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/site/annotation/DefaultSitePreferenceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/AbstractSitePathUrlFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/MobileSitePathUrlFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/NormalSitePathUrlFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/ServerNameSiteUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/ServerNameSiteUrlFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptorTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherHandlerInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilterTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/SiteSwitcherRequestFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/TabletSitePathUrlFactoryTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/TabletSitePathUrlFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/EmptySiteSwitcherAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/EmptySiteSwitcherAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/EmptySiteSwitcherConfiguration.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/EmptySiteSwitcherConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/MdotSiteSwitcherAnnotationTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/MdotSiteSwitcherAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/MdotSiteSwitcherConfiguration.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/switcher/annotation/MdotSiteSwitcherConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-device/src/test/java/org/springframework/mobile/device/view/LiteDeviceDelegatingViewResolverTest.java
+++ b/spring-mobile-device/src/test/java/org/springframework/mobile/device/view/LiteDeviceDelegatingViewResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 105 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).